### PR TITLE
Compatability fix for ESPHome 2023.12

### DIFF
--- a/components/gc9a01/display.py
+++ b/components/gc9a01/display.py
@@ -12,6 +12,7 @@ from esphome.const import (
     CONF_WIDTH,
     CONF_HEIGHT,
 )
+from esphome.const import __version__ as ESPHOME_VERSION
 
 CODEOWNERS = ["@4cello"]
 # adapted from https://github.com/PaintYourDragon/Adafruit_GC9A01A
@@ -52,7 +53,8 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def setup_gc9a01(var, config):
-    await cg.register_component(var, config)
+   if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
+        await cg.register_component(var, config)
     await display.register_display(var, config)
 
     if CONF_RESET_PIN in config:

--- a/components/gc9a01/display.py
+++ b/components/gc9a01/display.py
@@ -53,7 +53,7 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def setup_gc9a01(var, config):
-   if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
+    if cv.Version.parse(ESPHOME_VERSION) < cv.Version.parse("2023.12.0"):
         await cg.register_component(var, config)
     await display.register_display(var, config)
 

--- a/components/gc9a01/gc9a01.h
+++ b/components/gc9a01/gc9a01.h
@@ -1,14 +1,18 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/version.h"
 #include "esphome/components/spi/spi.h"
 #include "esphome/components/display/display_buffer.h"
 
 namespace esphome {
 namespace gc9a01 {
 
-class GC9A01 : public PollingComponent,
-               public display::DisplayBuffer,
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2023, 12, 0)
+class GC9A01 : public display::DisplayBuffer,
+#else
+class GC9A01 : public PollingComponent, public display::DisplayBuffer,
+#endif  // VERSION_CODE(2023, 12, 0)
                public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING,
                                      spi::DATA_RATE_40MHZ> {
  public:


### PR DESCRIPTION
This should be a fix for https://github.com/zagnuts/esphome-components/issues/1

There may be some extra work required for Waveshare devices.

Thanks for the great work.